### PR TITLE
Fix version files' URL properties

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version
@@ -1,6 +1,6 @@
 {
     "NAME":"SunkWorks",
-    "URL":"https://raw.githubusercontent.com/Angel-125/SunkWorks/master/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/SunkWorks/main/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version",
     "DOWNLOAD":"https://github.com/Angel-125/SunkWorks/releases",
     "GITHUB":
     {

--- a/SunkWorks.version
+++ b/SunkWorks.version
@@ -1,6 +1,6 @@
 {
     "NAME":"SunkWorks",
-    "URL":"https://raw.githubusercontent.com/Angel-125/SunkWorks/master/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/SunkWorks/main/ReleaseFolder/GameData/WildBlueIndustries/SunkWorks/SunkWorks.version",
     "DOWNLOAD":"https://github.com/Angel-125/SunkWorks/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125,

This repo has a `main` branch, but the version files currently say `master`. Now it's fixed.

Noticed while working on KSP-CKAN/NetKAN#10250.

![image](https://github.com/user-attachments/assets/aca8ed28-cb51-46c1-978b-01382a7b871f)

Cheers!
